### PR TITLE
Added media_kind to 'executing phantom' message

### DIFF
--- a/perform_analysis.py
+++ b/perform_analysis.py
@@ -418,11 +418,12 @@ def do_phantomjs(local_phantomjs, url, destfile, media_kind):
         # "nohup: ignoring input and appending output to ‘nohup.out’"
         p.stdout.readline()
 
-        print colored("+ %03d..%03d/%03d\tExecuting %s on: %s" %
+        print colored("+ %03d..%03d/%03d\tExecuting %s on: %s (%s)" %
                 ( PhantomCrawl.media_running,
                   PhantomCrawl.media_done,
                   PhantomCrawl.media_amount,
-                  binary, url), "green")
+                  binary, url,
+                  media_kind), "green")
 
         # wait 60 seconds, and then kill the process if is not worked properly
         time.sleep(60)


### PR DESCRIPTION
I found it a bit confusing when the script started fetching www.spiegelde instead of something from the Dutch list (which I was using), but this was because spiegel.de is one of the global URLs. So I added the media_kind (global, national, local) to the 'executing phantom' message to make this more clear.